### PR TITLE
Remove invalid characters from SendGrid API key in test data

### DIFF
--- a/src/DEFAUT_TEXT.ts
+++ b/src/DEFAUT_TEXT.ts
@@ -4,7 +4,7 @@ URL: https://user:pass@example.com
 
 GitHub Token: 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
 
-SendGrid: "SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528Kewhere"
+SendGrid: "SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528K"
 
 AWS_SECRET_ACCESS_KEY = wJalrXUtnFEMI/K7MDENG/bPxRfiCYSECRETSKEY
 


### PR DESCRIPTION
## Summary

Fixes the SendGrid API key in the demo so the rule actually detects it.

`@secretlint/secretlint-rule-sendgrid` enforces the official 69-character length (secretlint/secretlint#1132). The previous demo token was 75 characters (`...L5528Kewhere`), so the rule skipped it and the demo no longer showed a SendGrid finding. Trimming `ewhere` brings it to exactly 69 characters and restores detection.

## Changes
- `src/DEFAUT_TEXT.ts`: `...L5528Kewhere` → `...L5528K` (69 chars)

Closes secretlint/secretlint#1509

https://claude.ai/code/session_01FomGx1tfHbHaq5dT3ZLViJ